### PR TITLE
Fix @sprintf format-string concatenation errors

### DIFF
--- a/example/interactive_dashboard.jl
+++ b/example/interactive_dashboard.jl
@@ -228,14 +228,7 @@ function draw_aircraft!(ax, ac, col)
         strokecolor = col,
         strokewidth = 2.5,
         inspector_label = (_, _, _) ->
-            @sprintf("Wing\n" *
-                     "Span:     %.1f m     AR: %.2f\n" *
-                     "Sweep:    %.1f°     S:  %.0f m²\n" *
-                     "Root c:   %.2f m   Tip c: %.2f m\n" *
-                     "λ_in: %.3f  λ_out: %.3f\n" *
-                     "—— Cruise ——\n" *
-                     "CL: %.4f   CD_wing: %.5f\n" *
-                     "L/D: %.2f",
+            @sprintf("Wing\nSpan:     %.1f m     AR: %.2f\nSweep:    %.1f°     S:  %.0f m²\nRoot c:   %.2f m   Tip c: %.2f m\nλ_in: %.3f  λ_out: %.3f\n—— Cruise ——\nCL: %.4f   CD_wing: %.5f\nL/D: %.2f",
                 w.layout.span, w.layout.AR, w.layout.sweep, w.layout.S,
                 w.layout.root_chord, w.layout.root_chord * w.outboard.λ,
                 w.inboard.λ, w.outboard.λ,
@@ -264,12 +257,7 @@ function draw_aircraft!(ax, ac, col)
         strokecolor  = col,
         strokewidth  = 2.5,
         inspector_label = (_, _, _) ->
-            @sprintf("Fuselage\n" *
-                     "Length:   %.1f m\n" *
-                     "Radius:   %.3f m\n" *
-                     "Weight:   %.2f t\n" *
-                     "Pax shell: %.1f – %.1f m\n" *
-                     "nDecks: %d",
+            @sprintf("Fuselage\nLength:   %.1f m\nRadius:   %.3f m\nWeight:   %.2f t\nPax shell: %.1f - %.1f m\nnDecks: %d",
                 ac.fuselage.layout.x_end - ac.fuselage.layout.x_nose,
                 ac.fuselage.layout.radius,
                 ac.fuselage.weight / 9.81e3,
@@ -285,12 +273,7 @@ function draw_aircraft!(ax, ac, col)
         strokecolor  = col,
         strokewidth  = 2.0,
         inspector_label = (_, _, _) ->
-            @sprintf("H-Tail\n" *
-                     "Span: %.1f m   S: %.1f m²\n" *
-                     "Sweep: %.1f°   AR: %.2f\n" *
-                     "λ_tip: %.3f\n" *
-                     "Weight: %.3f t\n" *
-                     "CL_h (cruise): %.4f",
+            @sprintf("H-Tail\nSpan: %.1f m   S: %.1f m2\nSweep: %.1f deg   AR: %.2f\nlambda_tip: %.3f\nWeight: %.3f t\nCL_h (cruise): %.4f",
                 sqrt(ac.htail.layout.S * ac.htail.layout.AR),
                 ac.htail.layout.S,
                 ac.htail.layout.sweep, ac.htail.layout.AR,
@@ -306,14 +289,7 @@ function draw_aircraft!(ax, ac, col)
             strokecolor  = RGBf(0.9,0.2,0.1),
             strokewidth  = 1.5,
             inspector_label = (_, _, _) ->
-                @sprintf("Engine\n" *
-                         "Fan Dia:  %.3f m\n" *
-                         "N_eng:    %d\n" *
-                         "—— Cruise ——\n" *
-                         "BPR:  %.2f    OPR:  %.1f\n" *
-                         "Tt4:  %.0f K\n" *
-                         "TSFC: %.4f mg/N/s\n" *
-                         "FPR:  %.3f    LPC: %.3f   HPC: %.2f",
+                @sprintf("Engine\nFan Dia:  %.3f m\nN_eng:    %d\n-- Cruise --\nBPR:  %.2f    OPR:  %.1f\nTt4:  %.0f K\nTSFC: %.4f mg/N/s\nFPR:  %.3f    LPC: %.3f   HPC: %.2f",
                     pg[igdfan], Int(pg[igneng]),
                     pare[ieBPR,  ipcruise1], pare[ieOPR,  ipcruise1],
                     pare[ieTt4,  ipcruise1],


### PR DESCRIPTION
@sprintf is a macro that requires a string literal as its first argument; using * to join multiple string literals produces a runtime expression which the macro cannot parse at compile time.

Collapsed all four multi-line @sprintf format strings in draw_aircraft! (wing, fuselage, htail, engine inspector labels) into single string literals.  Also replaced non-ASCII em-dash and special chars in the fuselage/htail labels with ASCII equivalents to avoid any locale issues.

https://claude.ai/code/session_015uGcxcPsXfNrxy2tbAdMb6

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

-
-
-

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. -->

Closes #

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->


**AI Statement (required)**

<!-- Please include one of the following options in your PR description:

- **No generative AI was used.** This contribution was written entirely without AI
  assistance.
- **Limited use of generative AI.**
  Standard or boilerplate code snippets were generated with AI and manually reviewed;
  all design, logic, and implementation decisions were made by the contributor.
  Examples: IDE code-completions or brief LLM queries for common patterns.
- **Extensive use of generative AI.**
  Significant portions of code or documentation were generated with AI, including
  logic and implementation decisions. All generated code and documentation were
  reviewed and understood by the contributor. Examples: Output from agentic coding
  tools and/or substantial refactoring by LLMs (web-based or local).

 -->


**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] All tests are passing
- [ ] AI Statement is included
- [ ] The pull request is ready for review

Checklist and Template based on [Cantera's PR template](https://github.com/Cantera/cantera/tree/main)
